### PR TITLE
Remove usages of deprecated function

### DIFF
--- a/src/arpdiscover.c
+++ b/src/arpdiscover.c
@@ -69,14 +69,9 @@ int main (int argc, char **argv) {
         interface = argv[3];
 
     if (interface == NULL)
-        interface = pcap_lookupdev(pcap_error_buffer);
+        interface = pcap_get_first_interface(pcap_error_buffer);
 
-    if (interface == NULL) {
-        fprintf(stderr, "pcap_lookupdev: %s\n", pcap_error_buffer);
-        exit(EXIT_FAILURE);
-    }
-
-    printf ("using inteface %s\n", interface);
+    printf ("using interface %s\n", interface);
 
     if ((pcap_handle = pcap_open_live(interface, BUFSIZ, 1, 0, pcap_error_buffer)) == NULL) {
         fprintf(stderr, "pcap_open_live: %s\n", pcap_error_buffer);

--- a/src/arpdiscover.c
+++ b/src/arpdiscover.c
@@ -39,6 +39,7 @@
 
 int main (int argc, char **argv) {
     char *interface = NULL;
+    pcap_if_t *pcap_alldevs = NULL;
     pcap_t *pcap_handle = NULL;
     libnet_t *libnet_handle = NULL;
     char pcap_error_buffer[PCAP_ERRBUF_SIZE];
@@ -69,7 +70,7 @@ int main (int argc, char **argv) {
         interface = argv[3];
 
     if (interface == NULL)
-        interface = pcap_get_first_interface(pcap_error_buffer);
+        interface = pcap_get_first_interface(&pcap_alldevs, pcap_error_buffer);
 
     printf ("using interface %s\n", interface);
 
@@ -198,6 +199,9 @@ int main (int argc, char **argv) {
 
     libnet_destroy(libnet_handle);
     pcap_close(pcap_handle);
+
+    if(pcap_alldevs != NULL)
+        pcap_freealldevs(pcap_alldevs);
 
     printf("scanner terminated\n");
 

--- a/src/arpflood.c
+++ b/src/arpflood.c
@@ -64,14 +64,9 @@ int main (int argc, char **argv) {
         interface = argv[2];
 
     if (interface == NULL)
-        interface = pcap_lookupdev(pcap_error_buffer);
+        interface = pcap_get_first_interface(pcap_error_buffer);
 
-    if (interface == NULL) {
-        fprintf(stderr, "pcap_lookupdev: %s\n", pcap_error_buffer);
-        exit(EXIT_FAILURE);
-    }
-
-    printf ("using inteface %s\n", interface);
+    printf ("using interface %s\n", interface);
 
     if ((pcap_handle = pcap_open_live(interface, BUFSIZ, 1, 0, pcap_error_buffer)) == NULL) {
         fprintf(stderr, "pcap_open_live: %s\n", pcap_error_buffer);

--- a/src/arpflood.c
+++ b/src/arpflood.c
@@ -39,6 +39,7 @@
 
 int main (int argc, char **argv) {
     char *interface = NULL;
+    pcap_if_t *pcap_alldevs = NULL;
     pcap_t *pcap_handle = NULL;
     libnet_t *libnet_handle = NULL;
     char pcap_error_buffer[PCAP_ERRBUF_SIZE];
@@ -64,7 +65,7 @@ int main (int argc, char **argv) {
         interface = argv[2];
 
     if (interface == NULL)
-        interface = pcap_get_first_interface(pcap_error_buffer);
+        interface = pcap_get_first_interface(&pcap_alldevs, pcap_error_buffer);
 
     printf ("using interface %s\n", interface);
 
@@ -182,6 +183,9 @@ int main (int argc, char **argv) {
 
     libnet_destroy(libnet_handle);
     pcap_close(pcap_handle);
+
+    if(pcap_alldevs != NULL)
+        pcap_freealldevs(pcap_alldevs);
 
     return EXIT_SUCCESS;
 }

--- a/src/arppoison.c
+++ b/src/arppoison.c
@@ -57,14 +57,9 @@ int main (int argc, char **argv) {
         interface = argv[1];
 
     if (interface == NULL)
-        interface = pcap_lookupdev(pcap_error_buffer);
+        interface = pcap_get_first_interface(pcap_error_buffer);
 
-    if (interface == NULL) {
-        fprintf(stderr, "pcap_lookupdev: %s\n", pcap_error_buffer);
-        exit(EXIT_FAILURE);
-    }
-
-    printf ("using inteface %s\n", interface);
+    printf ("using interface %s\n", interface);
 
     if ((libnet_handle = libnet_init(LIBNET_LINK_ADV, interface, libnet_error_buffer)) == NULL) {
         fprintf(stderr, "%s", libnet_error_buffer);

--- a/src/arppoison.c
+++ b/src/arppoison.c
@@ -43,6 +43,7 @@
 
 int main (int argc, char **argv) {
     char *interface = NULL;
+    pcap_if_t *pcap_alldevs = NULL;
     libnet_t *libnet_handle = NULL;
     char pcap_error_buffer[PCAP_ERRBUF_SIZE];
     char libnet_error_buffer[LIBNET_ERRBUF_SIZE];
@@ -57,7 +58,7 @@ int main (int argc, char **argv) {
         interface = argv[1];
 
     if (interface == NULL)
-        interface = pcap_get_first_interface(pcap_error_buffer);
+        interface = pcap_get_first_interface(&pcap_alldevs, pcap_error_buffer);
 
     printf ("using interface %s\n", interface);
 
@@ -140,6 +141,9 @@ int main (int argc, char **argv) {
     }
 
     libnet_destroy(libnet_handle);
+
+    if(pcap_alldevs != NULL)
+        pcap_freealldevs(pcap_alldevs);
 
     return EXIT_SUCCESS;
 }

--- a/src/common.c
+++ b/src/common.c
@@ -21,6 +21,7 @@
 
 #define _GNU_SOURCE
 /* standard headers */
+#include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <sys/types.h>
@@ -61,4 +62,28 @@ char *hw_ntoa(struct libnet_ether_addr *hw) {
     str[6*2+5] = '\0';
 
     return str;
+}
+
+char *pcap_get_first_interface(char *pcap_error_buffer) {
+    pcap_if_t *pcap_alldevs;
+
+    if(pcap_findalldevs(&pcap_alldevs, pcap_error_buffer)) {
+        fprintf(stderr, "pcap_findalldevs: %s\n", pcap_error_buffer);
+        exit(EXIT_FAILURE);
+    }
+    if(pcap_alldevs == NULL) {
+        fprintf(stderr, "pcap_findalldevs: no devices found\n");
+        exit(EXIT_FAILURE);
+    }
+
+    const size_t len = strlen(pcap_alldevs[0].name);
+    char *result = malloc(len+1);
+    if(result == NULL) {
+        fprintf(stderr, "%s\n", strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+    memcpy(result, pcap_alldevs[0].name, len+1);
+
+    pcap_freealldevs(pcap_alldevs);
+    return result;
 }

--- a/src/common.c
+++ b/src/common.c
@@ -21,7 +21,6 @@
 
 #define _GNU_SOURCE
 /* standard headers */
-#include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <sys/types.h>
@@ -64,26 +63,15 @@ char *hw_ntoa(struct libnet_ether_addr *hw) {
     return str;
 }
 
-char *pcap_get_first_interface(char *pcap_error_buffer) {
-    pcap_if_t *pcap_alldevs;
-
-    if(pcap_findalldevs(&pcap_alldevs, pcap_error_buffer)) {
+char *pcap_get_first_interface(pcap_if_t **pcap_alldevs, char *pcap_error_buffer) {
+    if(pcap_findalldevs(pcap_alldevs, pcap_error_buffer)) {
         fprintf(stderr, "pcap_findalldevs: %s\n", pcap_error_buffer);
         exit(EXIT_FAILURE);
     }
-    if(pcap_alldevs == NULL) {
+    if(*pcap_alldevs == NULL) {
         fprintf(stderr, "pcap_findalldevs: no devices found\n");
         exit(EXIT_FAILURE);
     }
 
-    const size_t len = strlen(pcap_alldevs[0].name);
-    char *result = malloc(len+1);
-    if(result == NULL) {
-        fprintf(stderr, "%s\n", strerror(errno));
-        exit(EXIT_FAILURE);
-    }
-    memcpy(result, pcap_alldevs[0].name, len+1);
-
-    pcap_freealldevs(pcap_alldevs);
-    return result;
+    return (**pcap_alldevs).name;
 }

--- a/src/common.h
+++ b/src/common.h
@@ -22,4 +22,4 @@
 void pcap_die (pcap_t *pcap_handle, char *message);
 void libnet_die (libnet_t *libnet_handle);
 char *hw_ntoa(struct libnet_ether_addr *hw);
-char *pcap_get_first_interface(char *pcap_error_buffer);
+char *pcap_get_first_interface(pcap_if_t **pcap_alldevs, char *pcap_error_buffer);

--- a/src/common.h
+++ b/src/common.h
@@ -22,3 +22,4 @@
 void pcap_die (pcap_t *pcap_handle, char *message);
 void libnet_die (libnet_t *libnet_handle);
 char *hw_ntoa(struct libnet_ether_addr *hw);
+char *pcap_get_first_interface(char *pcap_error_buffer);


### PR DESCRIPTION
[`pcap_lookupdev()`](https://npcap.com/guide/wpcap/pcap_lookupdev.html) is deprecated. This pull request changes the code to use [`pcap_findalldevs()`](https://npcap.com/guide/wpcap/pcap_findalldevs.html) instead, as recommended in the documentation.